### PR TITLE
Fix duplicate user record during creation

### DIFF
--- a/internal/usecases/lysk_server.go
+++ b/internal/usecases/lysk_server.go
@@ -4,6 +4,7 @@ import (
 	"lysk-battle-record/internal/datastores"
 	"lysk-battle-record/internal/pkg"
 	"lysk-battle-record/internal/sheet_clients"
+	"sync"
 )
 
 func InitLyskServer(orbitRecordStore datastores.RecordStore, orbitSheetClient sheet_clients.RecordSheetClient,
@@ -29,4 +30,5 @@ type LyskServer struct {
 	userStore                datastores.UserStore
 	userSheetClient          sheet_clients.UserSheetClient
 	auth                     *pkg.Authenticator
+	userCreationMutex        sync.Mutex
 }

--- a/internal/usecases/lysk_server.go
+++ b/internal/usecases/lysk_server.go
@@ -1,10 +1,11 @@
 package usecases
 
 import (
+	"sync"
+
 	"lysk-battle-record/internal/datastores"
 	"lysk-battle-record/internal/pkg"
 	"lysk-battle-record/internal/sheet_clients"
-	"sync"
 )
 
 func InitLyskServer(orbitRecordStore datastores.RecordStore, orbitSheetClient sheet_clients.RecordSheetClient,

--- a/internal/usecases/user.go
+++ b/internal/usecases/user.go
@@ -81,6 +81,9 @@ func (s *LyskServer) GetRanking(c *gin.Context) {
 }
 
 func (s *LyskServer) createUserIfNotExist(userId string) error {
+	s.userCreationMutex.Lock()
+	defer s.userCreationMutex.Unlock()
+
 	var user models.User
 	user.ID = userId
 
@@ -99,6 +102,9 @@ func (s *LyskServer) createUserIfNotExist(userId string) error {
 }
 
 func (s *LyskServer) CreateUser(c *gin.Context) {
+	s.userCreationMutex.Lock()
+	defer s.userCreationMutex.Unlock()
+
 	var user models.User
 	if err := c.BindJSON(&user); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})


### PR DESCRIPTION
User creation might have race condition:
- Request 1 tries to authenticate token x
- No token x in the user store, request 1 calls sheet API to create new record
- Request 2 tries to authenticate the same token x 
- No token x in the user store, request 2 calls sheet API to create new record
- Request 1 finishes creating the record for token x in sheet, updates the store
- Request 2 also finishes creating the record for token x in sheet, updates the store
- 2 copies of token x are now in the sheet and store 🌚